### PR TITLE
Fix For fileForPath

### DIFF
--- a/gnmvidispine/vidispine_api.py
+++ b/gnmvidispine/vidispine_api.py
@@ -409,7 +409,7 @@ class VSApi(object):
         while True:
             try:
                 n+=1
-                raw_body=self.raw_request(path.replace(' ', '%20'),method=method,matrix=matrix,query=query,body=body,accept=accept)
+                raw_body=self.raw_request(path.replace(' ', '%20').replace('{', '%7B').replace('}', '%7D'),method=method,matrix=matrix,query=query,body=body,accept=accept)
                 break
             except HTTPError as e:
                 if e.code==503: #server unavailable

--- a/gnmvidispine/vidispine_api.py
+++ b/gnmvidispine/vidispine_api.py
@@ -409,7 +409,7 @@ class VSApi(object):
         while True:
             try:
                 n+=1
-                raw_body=self.raw_request(path.replace(' ', '%20').replace('{', '%7B').replace('}', '%7D'),method=method,matrix=matrix,query=query,body=body,accept=accept)
+                raw_body=self.raw_request(path.replace(' ', '%20'),method=method,matrix=matrix,query=query,body=body,accept=accept)
                 break
             except HTTPError as e:
                 if e.code==503: #server unavailable

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -342,6 +342,7 @@ class VSStorage(VSApi):
     def fileForPath(self, path):
         path = self.stripOwnPath(path)
         logging.debug("VSStorage::fileForPath - actually looking for %s" % path)
+        logging.info("path: %s" % path)
         processed_path = path.replace('{', '%7B').replace('}', '%7D').replace('/', '%2F')
         response = self.request("/storage/{storage}/file/path/{path}".format(storage=self.name, path=processed_path),
                                 method="GET",

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -343,7 +343,8 @@ class VSStorage(VSApi):
         path = self.stripOwnPath(path)
         logging.debug("VSStorage::fileForPath - actually looking for %s" % path)
         logging.info("path: %s" % path)
-        processed_path = path.replace('{', '%7B').replace('}', '%7D').replace('/', '%2F')
+        # processed_path = path.replace('{', '%7B').replace('}', '%7D').replace('/', '%2F')
+        processed_path = urllib.parse.urlencode(path)
         response = self.request("/storage/{storage}/file/path/{path}".format(storage=self.name, path=processed_path),
                                 method="GET",
                                 matrix={'includeItem': 'True'})

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -344,7 +344,7 @@ class VSStorage(VSApi):
         logging.debug("VSStorage::fileForPath - actually looking for %s" % path)
         logging.info("path: %s" % path)
         # processed_path = path.replace('{', '%7B').replace('}', '%7D').replace('/', '%2F')
-        processed_path = urllib.parse.urlencode(path)
+        processed_path = urllib.parse.quote(path)
         response = self.request("/storage/{storage}/file/path/{path}".format(storage=self.name, path=processed_path),
                                 method="GET",
                                 matrix={'includeItem': 'True'})

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -342,10 +342,9 @@ class VSStorage(VSApi):
     def fileForPath(self, path):
         path = self.stripOwnPath(path)
         logging.debug("VSStorage::fileForPath - actually looking for %s" % path)
-        response = self.request("/storage/{storage}/file/byURI".format(storage=self.name),
+        response = self.request("/storage/{storage}/file/path/{path}".format(storage=self.name, path=path),
                                 method="GET",
-                                matrix={'includeItem': 'True',
-                                        'path': path})
+                                matrix={'includeItem': 'True'})
         return VSFile(self, response)
 
     def fileForID(self, vsid):

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -342,10 +342,10 @@ class VSStorage(VSApi):
     def fileForPath(self, path):
         path = self.stripOwnPath(path)
         logging.debug("VSStorage::fileForPath - actually looking for %s" % path)
-        response = self.request("/storage/{storage}/file".format(storage=self.name),
+        processed_path = path.replace('{', '%7B').replace('}', '%7D').replace('/', '%2F')
+        response = self.request("/storage/{storage}/file/path/{path}".format(storage=self.name, path=processed_path),
                                 method="GET",
-                                matrix={'includeItem': 'True',
-                                        'path': path})
+                                matrix={'includeItem': 'True'})
         return VSFile(self, response)
 
     def fileForID(self, vsid):

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -342,10 +342,7 @@ class VSStorage(VSApi):
     def fileForPath(self, path):
         path = self.stripOwnPath(path)
         logging.debug("VSStorage::fileForPath - actually looking for %s" % path)
-        logging.info("path: %s" % path)
-        # processed_path = path.replace('{', '%7B').replace('}', '%7D').replace('/', '%2F')
         processed_path = urllib.parse.quote(path).replace('/', '%2F')
-        logging.info("processed_path: %s" % processed_path)
         response = self.request("/storage/{storage}/file/path/{path}".format(storage=self.name, path=processed_path),
                                 method="GET",
                                 matrix={'includeItem': 'True'})

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -344,7 +344,8 @@ class VSStorage(VSApi):
         logging.debug("VSStorage::fileForPath - actually looking for %s" % path)
         logging.info("path: %s" % path)
         # processed_path = path.replace('{', '%7B').replace('}', '%7D').replace('/', '%2F')
-        processed_path = urllib.parse.quote(path)
+        processed_path = urllib.parse.quote(path).replace('/', '%2F')
+        logging.info("processed_path: %s" % processed_path)
         response = self.request("/storage/{storage}/file/path/{path}".format(storage=self.name, path=processed_path),
                                 method="GET",
                                 matrix={'includeItem': 'True'})

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -342,9 +342,10 @@ class VSStorage(VSApi):
     def fileForPath(self, path):
         path = self.stripOwnPath(path)
         logging.debug("VSStorage::fileForPath - actually looking for %s" % path)
-        response = self.request("/storage/{storage}/file/path/{path}".format(storage=self.name, path=path),
+        response = self.request("/storage/{storage}/file".format(storage=self.name),
                                 method="GET",
-                                matrix={'includeItem': 'True'})
+                                matrix={'includeItem': 'True',
+                                        'path': path})
         return VSFile(self, response)
 
     def fileForID(self, vsid):


### PR DESCRIPTION
## What does this change?

Fixes the fileForPath method so it can now cope with characters such as {, }, and –.

## How can we measure success?

Paths are now processed correctly.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.